### PR TITLE
fix: verify Airlock Digital certificates by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 -------- | -------- | ---- | -----------
 **apiKey** | required | password | Airlock API Key |
 **base_url** | required | string | Airlock Digital REST API URL |
+**verify_server_cert** | optional | boolean | Verify the Airlock Digital server certificate |
 
 ### Supported Actions
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Airlock Digital
 
-Publisher: Domenico Perre & Airlock Digital Pty Ltd \
-Connector Version: 2.0.1 \
-Product Vendor: Airlock \
-Product Name: Airlock Digital \
+Publisher: Domenico Perre & Airlock Digital Pty Ltd <br>
+Connector Version: 2.0.1 <br>
+Product Vendor: Airlock <br>
+Product Name: Airlock Digital <br>
 Minimum Product Version: 5.3.3
 
 This app provides investigative, containment, and management actions for Airlock Digital's Execution Control & Allow listing endpoint product
@@ -19,24 +19,24 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[unblock hash](#action-unblock-hash) - Unblock (remove) hashes from one or more Blocklist policies \
-[disallow hash](#action-disallow-hash) - Disallow (remove) hashes from one or more Application Captures \
-[list identifiers](#action-list-identifiers) - Gathers a list of identifiers which are required for referencing groups, applications, baselines, or blocklists in other actions \
-[list policy](#action-list-policy) - List the policy configuration of a specified group \
-[move endpoint](#action-move-endpoint) - Moves an endpoint from one group to another \
-[allow hash](#action-allow-hash) - Allow (add) hashes in an Application Capture policy \
-[block hash](#action-block-hash) - Block (add) hashes in a Blocklist policy \
-[list endpoints](#action-list-endpoints) - List all the registered agents \
-[revoke otp](#action-revoke-otp) - Revoke the One Time Password \
-[retrieve otp](#action-retrieve-otp) - Retrieve the One Time Password \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[unblock hash](#action-unblock-hash) - Unblock (remove) hashes from one or more Blocklist policies <br>
+[disallow hash](#action-disallow-hash) - Disallow (remove) hashes from one or more Application Captures <br>
+[list identifiers](#action-list-identifiers) - Gathers a list of identifiers which are required for referencing groups, applications, baselines, or blocklists in other actions <br>
+[list policy](#action-list-policy) - List the policy configuration of a specified group <br>
+[move endpoint](#action-move-endpoint) - Moves an endpoint from one group to another <br>
+[allow hash](#action-allow-hash) - Allow (add) hashes in an Application Capture policy <br>
+[block hash](#action-block-hash) - Block (add) hashes in a Blocklist policy <br>
+[list endpoints](#action-list-endpoints) - List all the registered agents <br>
+[revoke otp](#action-revoke-otp) - Revoke the One Time Password <br>
+[retrieve otp](#action-retrieve-otp) - Retrieve the One Time Password <br>
 [lookup hash](#action-lookup-hash) - Lookup SHA256 hash
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 This endpoint will test connectivity with an Airlock Digital server.
@@ -53,7 +53,7 @@ No Output
 
 Unblock (remove) hashes from one or more Blocklist policies
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This action will unblock hashes from one or more Blocklist policies. This is useful if you want to 'un-ban' a particular hash value.
@@ -82,7 +82,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Disallow (remove) hashes from one or more Application Captures
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action will allow you to remove hashes for an existing Application Capture that exists on the Airlock Server.
@@ -111,7 +111,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Gathers a list of identifiers which are required for referencing groups, applications, baselines, or blocklists in other actions
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action gathers the identifiers which reference the groups, applications, baselines, or blocklists within Airlock. These identifiers are required to call other actions within the Phantom in order to interact with the Airlock Server.
@@ -141,7 +141,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 List the policy configuration of a specified group
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This action will return the policy configurations that are applied to the specified group, the group in this action is referenced by the Group ID.
@@ -207,7 +207,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Moves an endpoint from one group to another
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 This action moves an enforcement agent registration from one group within Airlock to another. This requires the destination Group ID to be referenced in the request as the 'target'. The source group does not need to be specified.
@@ -236,7 +236,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Allow (add) hashes in an Application Capture policy
 
-Type: **correct** \
+Type: **correct** <br>
 Read only: **False**
 
 This endpoint allows for the submission of a SHA256 hash value into an existing Application Capture policy.
@@ -267,7 +267,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Block (add) hashes in a Blocklist policy
 
-Type: **contain** \
+Type: **contain** <br>
 Read only: **False**
 
 This action allows you to add hashes to a Blocklist policy. By adding a hash into a Blocklist policy that is approved, it has the result of blocking the hash on endpoints within your environment.
@@ -296,7 +296,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 List all the registered agents
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 This endpoint will simply return a listing of registered agents from the Airlock Server. This list can be filtered based on certain criteria.
@@ -347,7 +347,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Revoke the One Time Password
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 Revoke an active OTP code by specifying the 'otpid' you want to revoke.
@@ -374,7 +374,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Retrieve the One Time Password
 
-Type: **generic** \
+Type: **generic** <br>
 Read only: **False**
 
 Retrieve an OTP code for a particular computer (agent) within Airlock. You must specify the OTP 'duration' and unique 'agentid' to retrieve the code. Unique 'agentid' parameters can be obtained from the /agent/find endpoint.
@@ -407,7 +407,7 @@ summary.total_objects_successful | numeric | | 10 |
 
 Lookup SHA256 hash
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 Query the Airlock file repository by specifying the hash value(s) you would like to lookup. NOTE: Only SHA256 hashes are supported.
@@ -455,7 +455,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/airlockdigital.json
+++ b/airlockdigital.json
@@ -2081,5 +2081,13 @@
                 "input_file": "wheels/shared/chardet-3.0.4-py2.py3-none-any.whl"
             }
         ]
+    },
+    "pip313_dependencies": {
+        "wheel": [
+            {
+                "module": "chardet",
+                "input_file": "wheels/shared/chardet-3.0.4-py2.py3-none-any.whl"
+            }
+        ]
     }
 }

--- a/airlockdigital.json
+++ b/airlockdigital.json
@@ -36,6 +36,13 @@
             "required": true,
             "default": "https://[airlockservername.com]:3129/v1",
             "order": 1
+        },
+        "verify_server_cert": {
+            "description": "Verify the Airlock Digital server certificate",
+            "data_type": "boolean",
+            "required": false,
+            "default": true,
+            "order": 2
         }
     },
     "actions": [

--- a/airlockdigital_connector.py
+++ b/airlockdigital_connector.py
@@ -218,7 +218,7 @@ class AirlockDigitalConnector(BaseConnector):
         url = f"{self._base_url}{endpoint}"
 
         try:
-            r = request_func(url, verify=config.get("verify_server_cert", False), **kwargs)
+            r = request_func(url, verify=config.get("verify_server_cert", True), **kwargs)
         except requests.exceptions.InvalidSchema:
             error_message = f"Error connecting to server. No connection adapters were found for {url}"
             return RetVal(action_result.set_status(phantom.APP_ERROR, error_message), resp_json)

--- a/airlockdigital_connector.py
+++ b/airlockdigital_connector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -243,7 +243,7 @@ class AirlockDigitalConnector(BaseConnector):
         self.save_progress("Connecting to endpoint")
 
         # make rest call
-        ret_val, response = self._make_rest_call(url, action_result, params=None, headers=self._header_var, method="post")
+        ret_val, _response = self._make_rest_call(url, action_result, params=None, headers=self._header_var, method="post")
 
         if phantom.is_fail(ret_val):
             self.save_progress("Test Connectivity Failed")

--- a/airlockdigital_consts.py
+++ b/airlockdigital_consts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Splunk Inc.
+# Copyright (c) 2025-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Verify Airlock Digital server certificates by default, with an explicit asset setting to opt out.


### PR DESCRIPTION
### Bug Fixes

- Verify Airlock Digital server certificates by default and add an explicit asset setting for operators who must opt out.
- Refresh shared pre-commit hooks and generated connector metadata before the functional remediation.

Tracking: [PAPP-38001](https://splunk.atlassian.net/browse/PAPP-38001), [PSAAS-31027](https://splunk.atlassian.net/browse/PSAAS-31027) (VULN-93752, FS-1860).

### Manual Documentation

<details><summary>
Have you made any changes that should be documented in manual_readme_content.md?
</summary><br />

The following changes require documentation in `manual_readme_content.md`:

- New, updated, or removed [REST handlers](https://docs.splunk.com/Documentation/SOAR/current/DevelopApps/RESTHandlers)
- New, updated, or removed authentication methods, especially complex methods like OAuth
- Compatibility considerations with respect to deployment types (e.g. actions that cannot be run on cloud or an automation broker)
</details>

- [x] I have verified that manual documentation has been updated where appropriate (the generated connector README documents the new asset setting; no manual content file exists).

### Testing

- `python3 -m py_compile airlockdigital_connector.py`
- `pre-commit run --all-files`
- The complete all-files Semgrep scan passed. Its staged-file commit invocation intermittently failed in Semgrep telemetry CA-store initialization; security scans are non-blocking under the campaign gate.

No connector-local unit-test scaffolding was added because this is a legacy BaseConnector app.

Written by Codex with AI assistance.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!
